### PR TITLE
Add initial Patch runtime

### DIFF
--- a/packages/runtime/localFns.ts
+++ b/packages/runtime/localFns.ts
@@ -1,5 +1,8 @@
-export const localFns: Record<string, (input: any) => any | Promise<any>> = {};
+export const localFns: Record<string, (input: unknown) => unknown | Promise<unknown>> = {};
 
-export function registerLocalFn(name: string, fn: (input: any) => any | Promise<any>): void {
-  localFns[name] = fn;
+export function registerLocalFn<Input = unknown, Output = unknown>(
+  name: string,
+  fn: (input: Input) => Output | Promise<Output>
+): void {
+  localFns[name] = fn as (input: unknown) => unknown | Promise<unknown>;
 }

--- a/packages/runtime/localFns.ts
+++ b/packages/runtime/localFns.ts
@@ -1,0 +1,5 @@
+export const localFns: Record<string, (input: any) => any | Promise<any>> = {};
+
+export function registerLocalFn(name: string, fn: (input: any) => any | Promise<any>): void {
+  localFns[name] = fn;
+}

--- a/packages/runtime/runPatch.ts
+++ b/packages/runtime/runPatch.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from 'crypto';
+import { PatchDefinition } from '../../types/Patch';
+import { Node } from '../../types/Node';
+import { topoSort } from './topoSort';
+import { localFns } from './localFns';
+
+export type PatchEvent =
+  | { type: 'RunStart'; runId: string; ts: number }
+  | { type: 'NodeStart'; nodeId: string; ts: number; input: any }
+  | { type: 'NodeSuccess'; nodeId: string; ts: number; output: any }
+  | { type: 'NodeError'; nodeId: string; ts: number; error: string }
+  | { type: 'RunComplete'; runId: string; ts: number };
+
+export async function* runPatch(
+  patch: PatchDefinition,
+  initialInput: any
+): AsyncGenerator<PatchEvent> {
+  const runId = randomUUID();
+  yield { type: 'RunStart', runId, ts: Date.now() } as PatchEvent;
+
+  const nodeMap = new Map<string, Node>();
+  for (const node of patch.nodes) nodeMap.set(node.id, node);
+
+  const order = topoSort(
+    patch.nodes.map(n => n.id),
+    patch.edges
+  );
+
+  const outputs = new Map<string, any>();
+
+  for (const nodeId of order) {
+    const node = nodeMap.get(nodeId)!;
+    const incoming = patch.edges.filter(e => e.target === nodeId);
+    let input: any;
+    if (incoming.length === 0) {
+      input = initialInput;
+    } else if (incoming.length === 1) {
+      input = outputs.get(incoming[0].source);
+    } else {
+      input = incoming.map(e => outputs.get(e.source));
+    }
+
+    yield { type: 'NodeStart', nodeId, ts: Date.now(), input } as PatchEvent;
+
+    try {
+      let output: any;
+      if (node.kind === 'http') {
+        const res = await fetch(node.url!, {
+          method: 'POST',
+          body: JSON.stringify(input),
+        });
+        output = await res.json();
+      } else if (node.kind === 'local') {
+        const fn = localFns[node.fn!];
+        if (!fn) throw new Error(`Local function not found: ${node.fn}`);
+        output = await fn(input);
+      } else {
+        throw new Error(`Unknown node kind: ${(node as any).kind}`);
+      }
+      outputs.set(nodeId, output);
+      yield { type: 'NodeSuccess', nodeId, ts: Date.now(), output } as PatchEvent;
+    } catch (err: any) {
+      yield {
+        type: 'NodeError',
+        nodeId,
+        ts: Date.now(),
+        error: String(err),
+      } as PatchEvent;
+      yield { type: 'RunComplete', runId, ts: Date.now() } as PatchEvent;
+      return;
+    }
+  }
+
+  // TODO: Parallel execution of independent nodes
+  // TODO: Streaming token-by-token output once nodes adopt SSE / chunked fetch
+  // TODO: Pluggable rate-limiting / retries
+
+  yield { type: 'RunComplete', runId, ts: Date.now() } as PatchEvent;
+}

--- a/packages/runtime/topoSort.ts
+++ b/packages/runtime/topoSort.ts
@@ -1,0 +1,36 @@
+export interface Edge {
+  source: string;
+  target: string;
+}
+
+export function topoSort(nodes: string[], edges: Edge[]): string[] {
+  const inDegree = new Map<string, number>();
+  for (const id of nodes) inDegree.set(id, 0);
+  for (const { source, target } of edges) {
+    inDegree.set(target, (inDegree.get(target) || 0) + 1);
+  }
+
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) queue.push(id);
+  }
+
+  const order: string[] = [];
+  while (queue.length) {
+    const id = queue.shift()!;
+    order.push(id);
+    for (const e of edges) {
+      if (e.source === id) {
+        const deg = (inDegree.get(e.target) || 0) - 1;
+        inDegree.set(e.target, deg);
+        if (deg === 0) queue.push(e.target);
+      }
+    }
+  }
+
+  if (order.length !== nodes.length) {
+    throw new Error('Cycle detected in patch graph');
+  }
+
+  return order;
+}

--- a/types/Node.ts
+++ b/types/Node.ts
@@ -1,0 +1,13 @@
+export interface HttpNode {
+  id: string;
+  kind: 'http';
+  url: string;
+}
+
+export interface LocalNode {
+  id: string;
+  kind: 'local';
+  fn: string;
+}
+
+export type Node = HttpNode | LocalNode;

--- a/types/Patch.ts
+++ b/types/Patch.ts
@@ -1,0 +1,11 @@
+import { Node } from './Node';
+
+export interface PatchEdge {
+  source: string;
+  target: string;
+}
+
+export interface PatchDefinition {
+  nodes: Node[];
+  edges: PatchEdge[];
+}


### PR DESCRIPTION
## Summary
- implement a basic streaming runtime that executes a Patch in topological order
- add Kahn based topo sort helper
- stub node and patch definition types
- add registry for local functions

## Testing
- `pnpm build` *(fails: Failed to fetch `Geist` fonts during Next build)*

------
https://chatgpt.com/codex/tasks/task_b_68434c961a548323bd181a138092a645