### PR TITLE
Add end-to-end runtime integration test

### DIFF
--- a/ISSUES_FROM_PR15_REVIEW.md
+++ b/ISSUES_FROM_PR15_REVIEW.md
@@ -1,0 +1,267 @@
+# GitHub Issues from PR #15 Review: End-to-End Integration Test
+
+This file contains 14 issues identified in the code review of `tests/integration/endToEndFlow.test.ts`. Each issue is structured for easy creation in GitHub Issues.
+
+---
+
+## Critical Issues (Priority: High)
+
+### Issue 1: Mock Validation Missing
+
+**File:** `tests/integration/endToEndFlow.test.ts:25-53`
+
+**Description:**
+The mock completely replaces the real API route but doesn't verify that the mock implementation matches the real one. This could lead to tests passing while the real implementation fails.
+
+**Problem Code:**
+```typescript
+jest.mock('@/apps/web/app/api/inlet/[id]/route', () => {
+  // Mock implementation that may not match real API
+});
+```
+
+**Suggested Solution:**
+Add a validation test that ensures the mock's `loadPatch` function signature matches the real implementation.
+
+**Labels:** `bug`, `testing`, `critical`
+
+---
+
+### Issue 2: Inconsistent Test Data
+
+**File:** `tests/integration/endToEndFlow.test.ts:98`
+
+**Description:**
+The test passes `{ number: 5 }` but expects the result to be `10`. While this is mathematically correct, the test lacks documentation explaining the expected transformation chain.
+
+**Problem Code:**
+```typescript
+body: JSON.stringify({ number: 5 })
+// Later expects result to be 10, but transformation chain is unclear
+```
+
+**Suggested Solution:**
+Add a comment explaining the expected transformation chain: `5 → doubleGear(10) → toStringGear("value=10") → revalidate("done")`.
+
+**Labels:** `documentation`, `testing`, `critical`
+
+---
+
+## Design Issues (Priority: Medium)
+
+### Issue 3: Hard-coded Mock Implementation
+
+**File:** `tests/integration/endToEndFlow.test.ts:67-80`
+
+**Description:**
+The mock implementations are overly specific to this test case, making them brittle and hard to extend for additional test scenarios.
+
+**Problem Code:**
+```typescript
+.mockImplementation(async (_src, input: any) =>
+  ((input.number as number) * 2) as unknown as any
+);
+```
+
+**Suggested Solution:**
+Make mock implementations more generic or add multiple test cases with different input types.
+
+**Labels:** `refactor`, `testing`, `enhancement`
+
+---
+
+### Issue 4: Missing Error Scenarios
+
+**File:** `tests/integration/endToEndFlow.test.ts`
+
+**Description:**
+The test only covers the happy path. Missing test cases for error scenarios that could occur in production.
+
+**Missing Test Cases:**
+- Invalid patch definitions
+- Missing local functions
+- Network errors in the streaming response
+- Malformed input data
+
+**Suggested Solution:**
+Add test cases for each error scenario to ensure robust error handling.
+
+**Labels:** `testing`, `enhancement`
+
+---
+
+### Issue 5: Limited Assertion Coverage
+
+**File:** `tests/integration/endToEndFlow.test.ts:126-129`
+
+**Description:**
+Current assertions only verify basic system prompt content but miss other important aspects of the gear behavior.
+
+**Current Code:**
+```typescript
+expect(doubleGear.systemPrompt()).toContain('Double the input number');
+expect(toStringGear.systemPrompt()).toContain('labelled string');
+```
+
+**Missing Assertions:**
+- Gears maintain their state correctly
+- Input flow between gears is correct
+- Gear instances are properly configured
+
+**Labels:** `testing`, `enhancement`
+
+---
+
+## Code Quality Issues (Priority: Medium)
+
+### Issue 6: Type Safety Concerns
+
+**File:** `tests/integration/endToEndFlow.test.ts:69, 80`
+
+**Description:**
+Multiple type assertions (`as unknown as any`) suggest the types might not be properly aligned, reducing type safety.
+
+**Problem Code:**
+```typescript
+((input.number as number) * 2) as unknown as any
+```
+
+**Suggested Solution:**
+Improve type definitions or use more specific types instead of casting to `any`.
+
+**Labels:** `typescript`, `refactor`
+
+---
+
+### Issue 7: Magic Numbers in Integration Test
+
+**File:** `tests/integration/endToEndFlow.test.ts`
+
+**Description:**
+The test uses magic numbers (`5`, `10`, `'/demo/path'`) without explanation, making the test harder to understand and maintain.
+
+**Suggested Solution:**
+Use named constants or add comments explaining the significance of these values.
+
+**Labels:** `refactor`, `code-quality`
+
+---
+
+### Issue 8: Inconsistent Async Patterns
+
+**File:** `tests/integration/endToEndFlow.test.ts`
+
+**Description:**
+Mix of `async/await` and promise-based patterns could be standardized for better readability and consistency.
+
+**Suggested Solution:**
+Standardize on one async pattern throughout the test file.
+
+**Labels:** `refactor`, `code-quality`
+
+---
+
+## Testing Best Practices (Priority: Medium)
+
+### Issue 9: Setup/Teardown Missing
+
+**File:** `tests/integration/endToEndFlow.test.ts`
+
+**Description:**
+Missing proper cleanup in `afterEach`/`afterAll` which could lead to test pollution and intermittent failures.
+
+**Suggested Solution:**
+Add proper test isolation with cleanup procedures.
+
+**Labels:** `testing`, `enhancement`
+
+---
+
+### Issue 10: Test Organization - Break Down Large Test
+
+**File:** `tests/integration/endToEndFlow.test.ts`
+
+**Description:**
+Single large test could be broken down into smaller, more focused tests for better maintainability and debugging.
+
+**Suggested Breakdown:**
+- Test patch execution separately from HTTP handling
+- Test gear chaining separately from the full pipeline
+- Test streaming behavior independently
+
+**Labels:** `refactor`, `testing`
+
+---
+
+### Issue 11: Documentation Missing
+
+**File:** `tests/integration/endToEndFlow.test.ts`
+
+**Description:**
+Missing JSDoc comments explaining what each part of the test verifies, making it harder for other developers to understand and maintain.
+
+**Suggested Solution:**
+Add comprehensive JSDoc comments throughout the test file.
+
+**Labels:** `documentation`, `testing`
+
+---
+
+## Minor Issues (Priority: Low)
+
+### Issue 12: Variable Naming Improvements
+
+**File:** `tests/integration/endToEndFlow.test.ts:107`
+
+**Description:**
+Variable name `text` for response body is not descriptive enough.
+
+**Suggested Solution:**
+Use a more descriptive variable name like `responseBody` or `streamResponse`.
+
+**Labels:** `refactor`, `minor`
+
+---
+
+### Issue 13: Extract Event Parsing Logic Helper
+
+**File:** `tests/integration/endToEndFlow.test.ts:110`
+
+**Description:**
+Event parsing logic could be extracted to a helper function for reusability across other tests.
+
+**Suggested Solution:**
+Create a utility function for parsing SSE events that can be shared across test files.
+
+**Labels:** `refactor`, `testing`, `minor`
+
+---
+
+### Issue 14: Split Large beforeAll Setup
+
+**File:** `tests/integration/endToEndFlow.test.ts:62-91`
+
+**Description:**
+The `beforeAll` setup is quite large and could benefit from being split into smaller helper functions for better readability.
+
+**Suggested Solution:**
+Extract setup logic into well-named helper functions that focus on specific aspects of the test setup.
+
+**Labels:** `refactor`, `minor`
+
+---
+
+## Summary
+
+**Total Issues:** 14
+- **Critical:** 2
+- **Medium Priority:** 8  
+- **Low Priority:** 4
+
+**Categories:**
+- **Testing Improvements:** 8 issues
+- **Code Quality:** 3 issues
+- **Documentation:** 2 issues
+- **TypeScript/Types:** 1 issue
+
+These issues were identified during the code review of the end-to-end integration test in PR #15. Addressing them will improve test reliability, maintainability, and code quality.

--- a/tests/integration/endToEndFlow.test.ts
+++ b/tests/integration/endToEndFlow.test.ts
@@ -1,0 +1,131 @@
+import { registerLocalFn } from '@/packages/runtime/localFns';
+import * as revalidateModule from '@/packages/outlets/revalidate';
+import { PatchDefinition } from '@/types/Patch';
+import { Gear } from '@/lib/models/gear';
+
+// Mock revalidate helper to observe calls
+jest.mock('@/packages/outlets/revalidate', () => ({
+  revalidate: jest.fn()
+}));
+
+// Build the mock patch used by the route
+const mockPatch: PatchDefinition = {
+  nodes: [
+    { id: 'nodeA', kind: 'local', fn: 'doubleGear' },
+    { id: 'nodeB', kind: 'local', fn: 'toStringGear' },
+    { id: 'outlet', kind: 'local', fn: 'revalidate' }
+  ],
+  edges: [
+    { source: 'nodeA', target: 'nodeB' },
+    { source: 'nodeB', target: 'outlet' }
+  ]
+};
+
+// Mock the API route so we can stub loadPatch
+jest.mock('@/apps/web/app/api/inlet/[id]/route', () => {
+  const { runPatch } = require('@/packages/runtime/runPatch');
+
+  const loadPatch = jest.fn(async (_id: string) => mockPatch);
+
+  function generatorToStream(gen: AsyncGenerator<any>) {
+    return new ReadableStream({
+      async pull(controller) {
+        const { value, done } = await gen.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        const text = `data: ${JSON.stringify(value)}\n\n`;
+        controller.enqueue(new TextEncoder().encode(text));
+      }
+    });
+  }
+
+  async function POST(req: Request, { params }: { params: { id: string } }) {
+    const payload = await req.json();
+    const patch = await loadPatch(params.id);
+    const gen = runPatch(patch, payload);
+    const stream = generatorToStream(gen);
+    return new Response(stream, { headers: { 'Content-Type': 'text/event-stream' } });
+  }
+
+  return { __esModule: true, POST, loadPatch };
+});
+
+import { POST } from '@/apps/web/app/api/inlet/[id]/route';
+
+describe('Patch Runtime end-to-end flow', () => {
+  let doubleGear: Gear;
+  let toStringGear: Gear;
+
+  beforeAll(async () => {
+    doubleGear = new Gear({ id: 'double-gear' });
+    await doubleGear.addMessage({
+      role: 'system',
+      content: 'Double the input number and return the result.'
+    });
+    jest
+      .spyOn(doubleGear, 'processWithoutLogging')
+      .mockImplementation(async (_src, input: any) =>
+        ((input.number as number) * 2) as unknown as any
+      );
+
+    toStringGear = new Gear({ id: 'toString-gear' });
+    await toStringGear.addMessage({
+      role: 'system',
+      content: 'Convert the number to a labelled string.'
+    });
+    jest
+      .spyOn(toStringGear, 'processWithoutLogging')
+      .mockImplementation(async (_src, input: any) => `value=${input}` as any);
+
+    registerLocalFn('doubleGear', (input: any) =>
+      doubleGear.processWithoutLogging('runtime', input)
+    );
+    registerLocalFn('toStringGear', (n: number) =>
+      toStringGear.processWithoutLogging('runtime', n as any)
+    );
+    registerLocalFn('revalidate', async () => {
+      await revalidateModule.revalidate(['/demo/path']);
+      return 'done';
+    });
+  });
+
+  it('executes patch via POST route and streams events', async () => {
+    const req = new Request('http://test/api/inlet/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ number: 5 })
+    });
+
+    const response = await POST(req, { params: { id: 'inlet' } });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+
+    const text = await response.text();
+    const events = text.trim().split('\n\n').map(chunk => JSON.parse(chunk.replace(/^data: /, '')));
+
+    const types = events.map(e => e.type);
+    expect(types).toEqual([
+      'RunStart',
+      'NodeStart',
+      'NodeSuccess',
+      'NodeStart',
+      'NodeSuccess',
+      'NodeStart',
+      'NodeSuccess',
+      'RunComplete'
+    ]);
+
+    expect(events[2].nodeId).toBe('nodeA');
+    expect(events[2].output).toBe(10);
+    expect(events[4].nodeId).toBe('nodeB');
+    expect(events[4].output).toBe('value=10');
+
+    expect(doubleGear.systemPrompt()).toContain('Double the input number');
+    expect(toStringGear.systemPrompt()).toContain('labelled string');
+    expect(revalidateModule.revalidate).toHaveBeenCalledTimes(1);
+    expect(revalidateModule.revalidate).toHaveBeenCalledWith(['/demo/path']);
+  });
+});


### PR DESCRIPTION
## Summary
- revise integration test to use Gear model and prompts

## Testing
- `npx jest tests/integration/endToEndFlow.test.ts --runInBand --verbose`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6844b87d1b608323b204a91a6f464620